### PR TITLE
Add links to README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ## <img src="/ktoml.png" width="300px"/>
 
-![Releases](https://img.shields.io/github/v/release/akuleshov7/ktoml)
-![Maven Central](https://img.shields.io/maven-central/v/com.akuleshov7/ktoml-core)
-![License](https://img.shields.io/github/license/akuleshov7/ktoml)
+[![Releases](https://img.shields.io/github/v/release/akuleshov7/ktoml)](https://github.com/orchestr7/ktoml/releases)
+[![Maven Central](https://img.shields.io/maven-central/v/com.akuleshov7/ktoml-core)](https://search.maven.org/artifact/com.akuleshov7/ktoml-core/)
+[![License](https://img.shields.io/github/license/akuleshov7/ktoml)](https://github.com/orchestr7/ktoml/blob/main/LICENSE)
 ![Build and test](https://github.com/akuleshov7/ktoml/actions/workflows/build_and_test.yml/badge.svg?branch=main)
 ![Lines of code](https://img.shields.io/tokei/lines/github/akuleshov7/ktoml)
 ![Hits-of-Code](https://hitsofcode.com/github/akuleshov7/ktoml?branch=main)


### PR DESCRIPTION
Hi, this PR makes some of the badges in the README clickable, so it's easier to view the releases and license.

Preview the changes in my fork: https://github.com/adam-enko/ktoml/blob/patch-1/README.md