### PR TITLE
Fix quoted and dotted keys

### DIFF
--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/parsers/StringUtils.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/parsers/StringUtils.kt
@@ -96,6 +96,25 @@ internal fun String.convertLineEndingBackslash(): String {
 internal fun String.trimQuotes(): String = trimSymbols(this, "\"", "\"")
 
 /**
+ * If this string starts and end with quotes("" or '') - will return the string with quotes removed
+ * Otherwise, returns this string.
+ *
+ * @return string with the result
+ */
+internal fun String.trimAllQuotes(): String {
+    val doubleQuote = "\""
+    val singleQuote = "'"
+
+    return if (this.startsWith(doubleQuote) && this.endsWith(doubleQuote)) {
+        this.removePrefix(doubleQuote).removeSuffix(doubleQuote)
+    } else if (this.startsWith(singleQuote) && this.endsWith(singleQuote)) {
+        this.removePrefix(singleQuote).removeSuffix(singleQuote)
+    } else {
+        this
+    }
+}
+
+/**
  * If this multiline string starts and end with triple quotes(""") - will return the string with
  * quotes and newline removed.
  * Otherwise, returns this string.

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/pairs/TomlKeyValue.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/pairs/TomlKeyValue.kt
@@ -3,6 +3,7 @@ package com.akuleshov7.ktoml.tree.nodes
 import com.akuleshov7.ktoml.TomlInputConfig
 import com.akuleshov7.ktoml.TomlOutputConfig
 import com.akuleshov7.ktoml.exceptions.ParseException
+import com.akuleshov7.ktoml.parsers.indexOfFirstOutsideQuotes
 import com.akuleshov7.ktoml.parsers.takeBeforeComment
 import com.akuleshov7.ktoml.tree.nodes.pairs.keys.TomlKey
 import com.akuleshov7.ktoml.tree.nodes.pairs.values.*
@@ -95,7 +96,7 @@ public fun String.splitKeyValue(lineNo: Int, config: TomlInputConfig = TomlInput
     val pair = takeBeforeComment(config.allowEscapedQuotesInLiteralStrings)
 
     // searching for an equals sign that should be placed main part of the string (not in the comment)
-    val firstEqualsSign = pair.indexOfFirst { it == '=' }
+    val firstEqualsSign = pair.indexOfFirstOutsideQuotes(config.allowEscapedQuotesInLiteralStrings, '=')
 
     // equals sign not found in the string
     if (firstEqualsSign == -1) {

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/pairs/keys/TomlKey.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/pairs/keys/TomlKey.kt
@@ -4,8 +4,7 @@ import com.akuleshov7.ktoml.TomlConfig
 import com.akuleshov7.ktoml.TomlOutputConfig
 import com.akuleshov7.ktoml.exceptions.TomlWritingException
 import com.akuleshov7.ktoml.parsers.splitKeyToTokens
-import com.akuleshov7.ktoml.parsers.trimQuotes
-import com.akuleshov7.ktoml.parsers.trimSingleQuotes
+import com.akuleshov7.ktoml.parsers.trimAllQuotes
 import com.akuleshov7.ktoml.writers.TomlEmitter
 import com.akuleshov7.ktoml.writers.TomlStringEmitter
 
@@ -50,10 +49,7 @@ public class TomlKey internal constructor(
      * Gets the last key part, with all whitespace and quotes trimmed, i.e. `c` in
      * `a.b.' c '`
      */
-    public fun last(): String = keyParts.last()
-        .trimQuotes()
-        .trimSingleQuotes()
-        .trim()
+    public fun last(): String = keyParts.last().trimAllQuotes().trim()
 
     @Deprecated(
         message = "TomlConfig is deprecated. Will be removed in next releases.",

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/pairs/keys/TomlKey.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/pairs/keys/TomlKey.kt
@@ -5,6 +5,7 @@ import com.akuleshov7.ktoml.TomlOutputConfig
 import com.akuleshov7.ktoml.exceptions.TomlWritingException
 import com.akuleshov7.ktoml.parsers.splitKeyToTokens
 import com.akuleshov7.ktoml.parsers.trimQuotes
+import com.akuleshov7.ktoml.parsers.trimSingleQuotes
 import com.akuleshov7.ktoml.writers.TomlEmitter
 import com.akuleshov7.ktoml.writers.TomlStringEmitter
 
@@ -49,7 +50,10 @@ public class TomlKey internal constructor(
      * Gets the last key part, with all whitespace and quotes trimmed, i.e. `c` in
      * `a.b.' c '`
      */
-    public fun last(): String = keyParts.last().trimQuotes().trim()
+    public fun last(): String = keyParts.last()
+        .trimQuotes()
+        .trimSingleQuotes()
+        .trim()
 
     @Deprecated(
         message = "TomlConfig is deprecated. Will be removed in next releases.",

--- a/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/decoders/keys/DottedKeysDecoderTest.kt
+++ b/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/decoders/keys/DottedKeysDecoderTest.kt
@@ -1,4 +1,4 @@
-package com.akuleshov7.ktoml.decoders
+package com.akuleshov7.ktoml.decoders.keys
 
 import com.akuleshov7.ktoml.Toml
 import com.akuleshov7.ktoml.TomlInputConfig
@@ -246,5 +246,29 @@ class DottedKeysDecoderTest {
             QuotedKey(a = AQ(b = ABCQ(b = BQ(d = 123)))),
             Toml.decodeFromString("a.\"a.b.c\".b.d = 123")
         )
+    }
+
+    @Serializable
+    data class Fruit(
+        val name: FruitName,
+    )
+
+    @Serializable
+    data class FruitName(
+        val value: String,
+    )
+
+    @Test
+    fun testWhitespacesAroundDottedKey() {
+        val toml1 = """
+            name.   value = "banana"
+        """.trimIndent()
+        val toml2 = """
+            name .   value = "banana"
+        """.trimIndent()
+        val expected = Fruit(FruitName("banana"))
+
+        assertEquals(expected, Toml.decodeFromString<Fruit>(toml1))
+        assertEquals(expected, Toml.decodeFromString<Fruit>(toml2))
     }
 }

--- a/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/decoders/keys/QuotedKeysDecoderTest.kt
+++ b/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/decoders/keys/QuotedKeysDecoderTest.kt
@@ -1,0 +1,50 @@
+package com.akuleshov7.ktoml.decoders.keys
+
+import com.akuleshov7.ktoml.Toml
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class QuotedKeysDecoderTest {
+
+    @Test
+    fun testSpecialSymbolsInQuotedKey() {
+        @Serializable
+        data class SpecialSymbolClass(
+            @SerialName("androidx.activity:activity-compose")
+            val value: Boolean,
+        )
+
+        val toml1 = """
+            "androidx.activity:activity-compose" = true
+        """.trimIndent()
+        val toml2 = """
+            'androidx.activity:activity-compose' = true
+        """.trimIndent()
+        val expected = SpecialSymbolClass(true)
+
+        assertEquals(expected, Toml.decodeFromString(toml1))
+        assertEquals(expected, Toml.decodeFromString(toml2))
+    }
+
+    @Test
+    fun testEqualSignInQuotedKey() {
+        @Serializable
+        data class EqualSignClass(
+            @SerialName("qwe=123")
+            val value: String,
+        )
+
+        val toml1 = """
+            "qwe=123" = 'bar'
+        """.trimIndent()
+        val toml2 = """
+            'qwe=123' = 'bar'
+        """.trimIndent()
+
+        assertEquals(EqualSignClass("bar"), Toml.decodeFromString(toml1))
+        assertEquals(EqualSignClass("bar"), Toml.decodeFromString(toml2))
+    }
+}

--- a/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/decoders/keys/QuotedKeysDecoderTest.kt
+++ b/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/decoders/keys/QuotedKeysDecoderTest.kt
@@ -43,8 +43,9 @@ class QuotedKeysDecoderTest {
         val toml2 = """
             'qwe=123' = 'bar'
         """.trimIndent()
+        val expected = EqualSignClass("bar")
 
-        assertEquals(EqualSignClass("bar"), Toml.decodeFromString(toml1))
-        assertEquals(EqualSignClass("bar"), Toml.decodeFromString(toml2))
+        assertEquals(expected, Toml.decodeFromString(toml1))
+        assertEquals(expected, Toml.decodeFromString(toml2))
     }
 }


### PR DESCRIPTION
Fixes #235

- Removed extra `trimQuotes()` in `String.validateSymbols()` to allow special symbols in quoted keys #235

- Added `trimSingleQuotes()` in `TomlKey.last()` to fix [this](https://github.com/orchestr7/ktoml/issues/235#issuecomment-2081630668) 

- Renamed `String.getCommentStartIndex` to `String.indexOfFirstOutsideQuotes` and extended it's usage to search for any symbol, which allows to use '=' in quoted keys

- Added extra `.trim()` in `String.splitKeyToTokens` to fit the following requirements:
  <img width="860" alt="image" src="https://github.com/user-attachments/assets/81e98c14-7266-4fb4-bd88-ee2364006c93" />
