### PR TITLE
Support Nested Inline Tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ We are still developing and testing this library, so it has several limitations:
 :white_check_mark: Multiline Strings \
 :white_check_mark: Arrays (including multiline and nested arrays) \
 :white_check_mark: Maps (for anonymous key-value pairs) \
+:white_check_mark: Nested Inline Tables \
 :x: Arrays: of Different Types \
-:x: Nested Inline Tables \
 :x: Array of Tables \
 :x: Inline Array of Tables
 

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/pairs/TomlKeyValue.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/pairs/TomlKeyValue.kt
@@ -3,7 +3,7 @@ package com.akuleshov7.ktoml.tree.nodes
 import com.akuleshov7.ktoml.TomlInputConfig
 import com.akuleshov7.ktoml.TomlOutputConfig
 import com.akuleshov7.ktoml.exceptions.ParseException
-import com.akuleshov7.ktoml.parsers.indexOfFirstOutsideQuotes
+import com.akuleshov7.ktoml.parsers.indexOfNextOutsideQuotes
 import com.akuleshov7.ktoml.parsers.takeBeforeComment
 import com.akuleshov7.ktoml.tree.nodes.pairs.keys.TomlKey
 import com.akuleshov7.ktoml.tree.nodes.pairs.values.*
@@ -96,7 +96,7 @@ public fun String.splitKeyValue(lineNo: Int, config: TomlInputConfig = TomlInput
     val pair = takeBeforeComment(config.allowEscapedQuotesInLiteralStrings)
 
     // searching for an equals sign that should be placed main part of the string (not in the comment)
-    val firstEqualsSign = pair.indexOfFirstOutsideQuotes(config.allowEscapedQuotesInLiteralStrings, '=')
+    val firstEqualsSign = pair.indexOfNextOutsideQuotes(config.allowEscapedQuotesInLiteralStrings, '=')
 
     // equals sign not found in the string
     if (firstEqualsSign == -1) {


### PR DESCRIPTION
Fixes #107

- Support Nested Inline Tables
- Support arrays in inline tables


First problem was in `TomlInlineTable::parseInlineTableValue`, when we called `.split(",")`. It doesn't work with arrays (cause they also have comma) and with nested inline tables. Now we do the same split, but ignore all commas inside arrays/nested inline.


Second problem was in `TomlInlineTable::returnTable`, in test case we had this TomlTable fullTableKey:
![image](https://github.com/user-attachments/assets/b2807071-8655-4b90-8ac4-771615cbe77a)
