### PR TITLE
Support unsigned integers

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ We are still developing and testing this library, so it has several limitations:
 :white_check_mark: Table sections (single and dotted) \
 :white_check_mark: Key-value pairs (single and dotted) \
 :white_check_mark: Long/Integer/Byte/Short types \
+:white_check_mark: Unsigned integer types \
 :white_check_mark: Double/Float types \
 :white_check_mark: Basic Strings \
 :white_check_mark: Literal Strings \

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/decoders/TomlAbstractDecoder.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/decoders/TomlAbstractDecoder.kt
@@ -22,7 +22,6 @@ import kotlinx.datetime.LocalTime
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.builtins.serializer
-import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.AbstractDecoder
 
 /**
@@ -35,10 +34,10 @@ public abstract class TomlAbstractDecoder : AbstractDecoder() {
     private val localDateTimeSerializer = LocalDateTime.serializer()
     private val localDateSerializer = LocalDate.serializer()
     private val localTimeSerializer = LocalTime.serializer()
-    private val uByteSerializer = UByte.serializer()
-    private val uShortSerializer = UShort.serializer()
-    private val uIntSerializer = UInt.serializer()
-    private val uLongSerializer = ULong.serializer()
+    private val unsignedByteSerializer = UByte.serializer()
+    private val unsignedShortSerializer = UShort.serializer()
+    private val unsignedIntSerializer = UInt.serializer()
+    private val unsignedLongSerializer = ULong.serializer()
 
     // Invalid Toml primitive types, but we anyway support them with some limitations
     override fun decodeByte(): Byte = decodePrimitiveType()
@@ -96,10 +95,10 @@ public abstract class TomlAbstractDecoder : AbstractDecoder() {
                 descriptor == localTimeSerializer.descriptor
 
     protected fun DeserializationStrategy<*>.isUnsigned(): Boolean =
-        descriptor == uByteSerializer.descriptor ||
-                descriptor == uShortSerializer.descriptor ||
-                descriptor == uIntSerializer.descriptor ||
-                descriptor == uLongSerializer.descriptor
+        descriptor == unsignedByteSerializer.descriptor ||
+                descriptor == unsignedShortSerializer.descriptor ||
+                descriptor == unsignedIntSerializer.descriptor ||
+                descriptor == unsignedLongSerializer.descriptor
 
     // Cases for date-time types
     @Suppress("UNCHECKED_CAST")
@@ -110,10 +109,10 @@ public abstract class TomlAbstractDecoder : AbstractDecoder() {
             localDateSerializer.descriptor -> decodePrimitiveType<LocalDate>() as T
             localTimeSerializer.descriptor -> decodePrimitiveType<LocalTime>() as T
 
-            uByteSerializer.descriptor -> decodeUnsignedPrimitiveType<UByte>() as T
-            uShortSerializer.descriptor -> decodeUnsignedPrimitiveType<UShort>() as T
-            uIntSerializer.descriptor -> decodeUnsignedPrimitiveType<UInt>() as T
-            uLongSerializer.descriptor -> decodeUnsignedPrimitiveType<ULong>() as T
+            unsignedByteSerializer.descriptor -> decodeUnsignedPrimitiveType<UByte>() as T
+            unsignedShortSerializer.descriptor -> decodeUnsignedPrimitiveType<UShort>() as T
+            unsignedIntSerializer.descriptor -> decodeUnsignedPrimitiveType<UInt>() as T
+            unsignedLongSerializer.descriptor -> decodeUnsignedPrimitiveType<ULong>() as T
             else -> super.decodeSerializableValue(deserializer)
         }
 

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/decoders/TomlArrayDecoder.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/decoders/TomlArrayDecoder.kt
@@ -89,7 +89,9 @@ public class TomlArrayDecoder(
     override fun decodeBoolean(): Boolean = currentElementDecoder.decodeBoolean()
     override fun decodeChar(): Char = currentElementDecoder.decodeChar()
     override fun decodeEnum(enumDescriptor: SerialDescriptor): Int = currentElementDecoder.decodeEnum(enumDescriptor)
-    override fun <T> decodeSerializableValue(deserializer: DeserializationStrategy<T>): T = if (deserializer.isDateTime()) {
+    override fun <T> decodeSerializableValue(deserializer: DeserializationStrategy<T>): T = if (
+        deserializer.isDateTime() || deserializer.isUnsigned()
+    ) {
         currentElementDecoder.decodeSerializableValue(deserializer)
     } else {
         super.decodeSerializableValue(deserializer)

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/pairs/TomlKeyValue.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/pairs/TomlKeyValue.kt
@@ -145,6 +145,7 @@ public fun String.parseValue(lineNo: Int, config: TomlInputConfig): TomlValue = 
         // ===== basic strings
         '\"' -> TomlBasicString(this, lineNo)
         else -> tryParseValue<NumberFormatException>(lineNo, ::TomlLong)  // ==== integer values
+            ?: tryParseValue<NumberFormatException>(lineNo, ::TomlUnsignedLong)  // ===== unsigned integer values
             ?: tryParseValue<NumberFormatException>(lineNo, ::TomlDouble)  // ===== float values
             ?: tryParseValue<IllegalArgumentException>(lineNo, ::TomlDateTime)  // ===== date-time values
             ?: TomlBasicString(this, lineNo)  // ===== fallback strategy in case of invalid value

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/pairs/values/TomlUnsignedLong.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/pairs/values/TomlUnsignedLong.kt
@@ -19,7 +19,6 @@ public class TomlUnsignedLong internal constructor(
     override var content: Any,
     public var representation: IntegerRepresentation = DECIMAL
 ) : TomlValue() {
-
     public constructor(content: String, lineNo: Int) : this(content.parse(lineNo))
 
     private constructor(pair: Pair<ULong, IntegerRepresentation>) : this(pair.first, pair.second)

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/pairs/values/TomlUnsignedLong.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/pairs/values/TomlUnsignedLong.kt
@@ -10,45 +10,47 @@ import com.akuleshov7.ktoml.writers.IntegerRepresentation.*
 import com.akuleshov7.ktoml.writers.TomlEmitter
 
 /**
- * Toml AST Node for a representation of Arbitrary 64-bit signed integers: key = 1
+ * Toml AST Node for a representation of Arbitrary 64-bit unsigned integers: key = 9_223_372_036_854_775_808
+ * This node contains integer in range: [2^63, 2^64-1]. Integers less than 2^63 are treated as TomlLong
  * @property content
  * @property representation The representation of the integer.
  */
-public class TomlLong internal constructor(
+public class TomlUnsignedLong internal constructor(
     override var content: Any,
     public var representation: IntegerRepresentation = DECIMAL
 ) : TomlValue() {
+
     public constructor(content: String, lineNo: Int) : this(content.parse(lineNo))
 
-    private constructor(pair: Pair<Long, IntegerRepresentation>) : this(pair.first, pair.second)
+    private constructor(pair: Pair<ULong, IntegerRepresentation>) : this(pair.first, pair.second)
 
     override fun write(
         emitter: TomlEmitter,
         config: TomlOutputConfig
     ) {
-        emitter.emitValue(content as Long, representation)
+        emitter.emitValue(content as ULong, representation)
     }
 
     private companion object {
         private val prefixRegex = "(?<=0[box])".toRegex()
 
-        private fun String.parse(lineNo: Int): Pair<Long, IntegerRepresentation> {
+        private fun String.parse(lineNo: Int): Pair<ULong, IntegerRepresentation> {
             val value = replace("_", "").split(prefixRegex, limit = 2)
 
             return if (value.size == 2) {
                 val (prefix, digits) = value
 
                 when (prefix) {
-                    "0b" -> digits.toLong(BIN_RADIX) to BINARY
-                    "0o" -> digits.toLong(OCT_RADIX) to OCTAL
-                    "0x" -> digits.toLong(HEX_RADIX) to HEX
+                    "0b" -> digits.toULong(BIN_RADIX) to BINARY
+                    "0o" -> digits.toULong(OCT_RADIX) to OCTAL
+                    "0x" -> digits.toULong(HEX_RADIX) to HEX
                     else -> throw ParseException(
-                        "Invalid radix prefix for Long number <$this> $prefix: expected \"0b\", \"0o\", or \"0x\".",
+                        "Invalid radix prefix for ULong number <$this> $prefix: expected \"0b\", \"0o\", or \"0x\".",
                         lineNo
                     )
                 }
             } else {
-                value.first().toLong() to DECIMAL
+                value.first().toULong() to DECIMAL
             }
         }
     }

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/utils/SpecialCharacters.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/utils/SpecialCharacters.kt
@@ -13,6 +13,8 @@ import com.akuleshov7.ktoml.exceptions.UnknownEscapeSymbolsException
 
 internal const val COMPLEX_UNICODE_LENGTH = 8
 internal const val COMPLEX_UNICODE_PREFIX = 'U'
+internal const val BIN_RADIX = 2
+internal const val OCT_RADIX = 8
 internal const val HEX_RADIX = 16
 internal const val SIMPLE_UNICODE_LENGTH = 4
 internal const val SIMPLE_UNICODE_PREFIX = 'u'

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/utils/Types.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/utils/Types.kt
@@ -31,6 +31,7 @@ public enum class FloatingPointLimitsEnum(public val min: Double, public val max
  * @property min
  * @property max
  */
+@Suppress("WRONG_DECLARATIONS_ORDER")
 public enum class UnsignedIntegerLimitsEnum(public val min: ULong, public val max: ULong) {
     U_BYTE(UByte.MIN_VALUE.toULong(), UByte.MAX_VALUE.toULong()),
     U_SHORT(UShort.MIN_VALUE.toULong(), UShort.MAX_VALUE.toULong()),

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/utils/Types.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/utils/Types.kt
@@ -15,14 +15,6 @@ public enum class IntegerLimitsEnum(public val min: Long, public val max: Long) 
     LONG(Long.MIN_VALUE, Long.MAX_VALUE),
     SHORT(Short.MIN_VALUE.toLong(), Short.MAX_VALUE.toLong()),
     ;
-    // Unsigned values are not supported now, and I think
-    // that will not be supported, because TOML spec says the following:
-    // Arbitrary 64-bit signed integers (from −2^63 to 2^63−1) should be accepted and handled losslessly.
-    // If an integer cannot be represented losslessly, an error must be thrown.
-    // U_BYTE(UByte.MIN_VALUE.toLong(), UByte.MAX_VALUE.toLong()),
-    // U_SHORT(UShort.MIN_VALUE.toLong(), UShort.MAX_VALUE.toLong()),
-    // U_INT(UInt.MIN_VALUE.toLong(), UInt.MAX_VALUE.toLong()),
-    // U_LONG(ULong.MIN_VALUE.toLong(), ULong.MAX_VALUE.toLong()),
 }
 
 /**
@@ -32,5 +24,17 @@ public enum class IntegerLimitsEnum(public val min: Long, public val max: Long) 
 public enum class FloatingPointLimitsEnum(public val min: Double, public val max: Double) {
     DOUBLE(-Double.MAX_VALUE, Double.MAX_VALUE),
     FLOAT(-Float.MAX_VALUE.toDouble(), Float.MAX_VALUE.toDouble()),
+    ;
+}
+
+/**
+ * @property min
+ * @property max
+ */
+public enum class UnsignedIntegerLimitsEnum(public val min: ULong, public val max: ULong) {
+    U_BYTE(UByte.MIN_VALUE.toULong(), UByte.MAX_VALUE.toULong()),
+    U_SHORT(UShort.MIN_VALUE.toULong(), UShort.MAX_VALUE.toULong()),
+    U_INT(UInt.MIN_VALUE.toULong(), UInt.MAX_VALUE.toULong()),
+    U_LONG(ULong.MIN_VALUE, ULong.MAX_VALUE),
     ;
 }

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/writers/TomlEmitter.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/writers/TomlEmitter.kt
@@ -284,6 +284,40 @@ public abstract class TomlEmitter(config: TomlOutputConfig) {
     }
 
     /**
+     * Emits an unsigned integer value, optionally changing its representation from decimal.
+     *
+     * @param unsignedInteger
+     * @param representation How the integer will be represented in TOML.
+     * @param groupSize The digit group size, or less than `1` for no grouping. For
+     * example, a group size of `3` emits `1_000_000`, `4` emits `0b1111_1111`, etc.
+     * @return this instance
+     */
+    public fun emitValue(
+        unsignedInteger: ULong,
+        representation: IntegerRepresentation = DECIMAL,
+        groupSize: Int = 0,
+    ): TomlEmitter {
+        if (representation == GROUPED) {
+            return emitValue(unsignedInteger, representation = DECIMAL, groupSize = 3)
+        }
+
+        if (unsignedInteger < 0u) {
+            emit('-')
+        }
+
+        var digits = unsignedInteger.toString(representation.radix).trimStart('-')
+
+        if (groupSize > 0) {
+            digits = (digits as CharSequence).reversed()
+                .chunked(groupSize, CharSequence::reversed)
+                .asReversed()
+                .joinToString(separator = "_")
+        }
+
+        return emit(representation.prefix).emit(digits)
+    }
+
+    /**
      * Emits a floating-point value.
      *
      * @param float

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/writers/TomlEmitter.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/writers/TomlEmitter.kt
@@ -292,6 +292,7 @@ public abstract class TomlEmitter(config: TomlOutputConfig) {
      * example, a group size of `3` emits `1_000_000`, `4` emits `0b1111_1111`, etc.
      * @return this instance
      */
+    @Suppress("SAY_NO_TO_VAR")
     public fun emitValue(
         unsignedInteger: ULong,
         representation: IntegerRepresentation = DECIMAL,

--- a/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/decoders/UnsignedNumbersDecoderTest.kt
+++ b/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/decoders/UnsignedNumbersDecoderTest.kt
@@ -1,0 +1,62 @@
+package com.akuleshov7.ktoml.decoders
+
+import com.akuleshov7.ktoml.Toml
+import com.akuleshov7.ktoml.exceptions.IllegalTypeException
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class UnsignedNumbersDecoderTest {
+
+    @Serializable
+    data class UnsignedIntegers(
+        val b: UByte = (Byte.MAX_VALUE + 1).toUByte(),
+        val s: UShort = (Short.MAX_VALUE + 1).toUShort(),
+        val i: UInt = (Int.MAX_VALUE + 1).toUInt(),
+        val l: ULong = (Long.MAX_VALUE + 1).toULong(),
+    )
+
+    @Test
+    fun decodeUnsignedIntegers() {
+        val toml = """
+              b = 128
+              s = 32768
+              i = 2147483648
+              l = 9_223_372_036_854_775_808
+        """.trimIndent()
+
+        assertEquals(UnsignedIntegers(), Toml.decodeFromString<UnsignedIntegers>(toml))
+    }
+
+    @Test
+    fun decodeUnsignedIntegersInArray() {
+        @Serializable
+        data class UnsignedIntegersArray(
+            val b: List<UByte> = listOf(1u, 2u, 3u, 4u),
+            val s: List<UInt> = listOf(1u, 2u, 3u, 4u),
+            val i: List<UInt> = listOf(1u, 2u, 3u, 4u),
+            val l: List<ULong> = listOf(1u, 2u, 3u, 4u),
+        )
+
+        val toml = """
+            b = [1, 2, 3, 4]
+            s = [1, 2, 3, 4]
+            i = [1, 2, 3, 4]
+            l = [1, 2, 3, 4]
+        """.trimIndent()
+        assertEquals(UnsignedIntegersArray(), Toml.decodeFromString<UnsignedIntegersArray>(toml))
+    }
+
+    @Test
+    fun shouldThrowExceptionOnOverflow() {
+        val toml = """
+            b = 256
+        """.trimIndent()
+
+        assertFailsWith<IllegalTypeException> {
+            Toml.decodeFromString<UnsignedIntegers>(toml)
+        }
+    }
+}

--- a/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/encoders/EncodingAnnotationTest.kt
+++ b/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/encoders/EncodingAnnotationTest.kt
@@ -231,6 +231,34 @@ class EncodingAnnotationTest {
     }
 
     @Test
+    fun unsignedIntegerRepresentationTest() {
+        @Serializable
+        data class File(
+            @TomlInteger(DECIMAL)
+            val dec: ULong = 0u,
+            @TomlInteger(BINARY)
+            val bin: ULong = 2u,
+            @TomlInteger(GROUPED)
+            val gro: ULong = 9_999_099_009u,
+            @TomlInteger(HEX)
+            val hex: ULong = 4u,
+            @TomlInteger(OCTAL)
+            val oct: ULong = 6u,
+        )
+
+        assertEncodedEquals(
+            value = File(),
+            expectedToml = """
+                dec = 0
+                bin = 0b10
+                gro = 9_999_099_009
+                hex = 0x4
+                oct = 0o6
+            """.trimIndent()
+        )
+    }
+
+    @Test
     fun literalStringTest() {
         @Serializable
         data class File(

--- a/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/writers/ValueWriteTest.kt
+++ b/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/writers/ValueWriteTest.kt
@@ -79,6 +79,29 @@ class PrimitiveValueWriteTest {
     }
 
     @Test
+    fun unsignedIntegerWriteTest() {
+        // Decimal
+        testTomlValue(TomlUnsignedLong(1234567UL), "1234567")
+        testTomlValue(TomlLong(Long.MIN_VALUE), "${Long.MIN_VALUE}")
+
+        // Hex
+        testTomlValue(TomlUnsignedLong(0xdeadc0deUL, IntegerRepresentation.HEX), "0xdeadc0de")
+        testTomlValue(TomlUnsignedLong(ULong.MIN_VALUE, IntegerRepresentation.HEX), "0x0")
+
+        // Binary
+        testTomlValue(TomlUnsignedLong(0b10000000UL, IntegerRepresentation.BINARY), "0b10000000")
+        testTomlValue(TomlUnsignedLong(ULong.MIN_VALUE, IntegerRepresentation.BINARY), "0b0")
+
+        // Octal
+        testTomlValue(TomlUnsignedLong(0x1FFUL, IntegerRepresentation.OCTAL), "0o777")
+        testTomlValue(TomlUnsignedLong(ULong.MIN_VALUE, IntegerRepresentation.OCTAL), "0o0")
+
+        // Grouped
+        testTomlValue(TomlUnsignedLong(1234567UL, IntegerRepresentation.GROUPED), "1_234_567")
+        testTomlValue(TomlUnsignedLong(ULong.MAX_VALUE, IntegerRepresentation.GROUPED), "18_446_744_073_709_551_615")
+    }
+
+    @Test
     fun floatWriteTest() {
         testTomlValue(TomlDouble(PI), "$PI")
         testTomlValue(TomlDouble(NaN), "nan")


### PR DESCRIPTION
Fixes #173 

> Neither signed, nor unsigned integers are subtypes of each other.

So there's a bit of code duplication in parsing and serialization between unsigned types and integers, but nothing crucial