### PR TITLE
Fix serialization of nested tables under empty parent tables

### DIFF
--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/tables/TomlTable.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/tables/TomlTable.kt
@@ -170,11 +170,14 @@ public class TomlTable(
             indent()
         }
 
-        if (child !is TomlTable ||
+        if (child !is TomlStubEmptyNode) {
+            if (child !is TomlTable ||
                 (child.type == TableType.PRIMITIVE &&
                         !child.isSynthetic &&
-                        child.getFirstChild() !is TomlTable)) {
-            emitIndent()
+                        child.getFirstChild() !is TomlTable)
+            ) {
+                emitIndent()
+            }
         }
 
         child.write(emitter = this, config)
@@ -199,8 +202,10 @@ public class TomlTable(
                 children.forEachIndexed { i, child ->
                     writeArrayChild(i, child, children, config)
                 }
+
             TableType.PRIMITIVE -> {
-                if (children.first() is TomlStubEmptyNode) {
+                // "children.count() == 1" condition relies on the behavior of the AST result
+                if (children.count() == 1 && children.first() is TomlStubEmptyNode) {
                     return
                 }
 

--- a/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/writers/TableWriteTest.kt
+++ b/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/writers/TableWriteTest.kt
@@ -77,6 +77,64 @@ class TableWriteTest {
 
         testTable(toml)
     }
+
+    @Test
+    fun emptySuperLevelTest() {
+        val toml = """
+            [a]
+            
+                [a.b]
+                    name = 1
+            
+                [a.c]
+                    name = 2
+        """.trimIndent()
+
+        testTable(toml)
+    }
+
+    @Test
+    fun complexEmptySuperLevelTest() {
+        val toml = """
+            [a]
+                name = 1
+
+                [a.b]
+            
+                    [a.b.c]
+                        name = 2
+            
+            [x]
+
+                [x.y]
+            
+                    [x.y.z]
+                        name = 2
+            
+            [m]
+
+                [m.n]
+            
+                    [m.n.k]
+                        name = 3
+            
+                    [m.n.l]
+                        name = 4
+            
+            [i]
+                name = 5
+
+                [i.j]
+            
+                    [i.j.k]
+                        name = 6
+            
+                    [i.j.l]
+                        name = 7
+        """.trimIndent()
+
+        testTable(toml)
+    }
 }
 
 fun testTable(


### PR DESCRIPTION
Fixed an issue where nested tables (e.g., [a.b], [a.c]) under an empty parent table (e.g., [a]) were omitted during serialization, leading to missing configuration data. This fix ensures that nested tables are properly serialized, even when their parent tables are empty.

#309
