### PR TITLE
Fixes around comments in/around multiline strings

### DIFF
--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/parsers/StringUtils.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/parsers/StringUtils.kt
@@ -7,6 +7,8 @@ package com.akuleshov7.ktoml.parsers
 import com.akuleshov7.ktoml.exceptions.ParseException
 import com.akuleshov7.ktoml.utils.newLineChar
 
+private const val MULTILINE_STRING_QUOTE_LENGTH = 3
+
 /**
  * Splitting dot-separated string to the list of tokens:
  * a.b.c -> [a, b, c]; a."b.c".d -> [a, "b.c", d];
@@ -220,25 +222,26 @@ internal fun String.indexOfNextOutsideQuotes(
         // take searchChar index if it's not enclosed in quotation marks
         if (symbol == searchChar && currentQuoteStr == null) {
             return idx + startIndex
+        } else if (symbol != '\"' && symbol != '\'') {
+            idx += 1
+            continue
         }
 
-        if (symbol == '\"' || symbol == '\'') {
-            val quoteStr = currentQuoteStr
-            if (quoteStr == null) {
-                if (idx + 2 < chars.length && chars[idx + 1] == symbol && chars[idx + 2] == symbol) {
-                    currentQuoteStr = "$symbol$symbol$symbol"
-                    idx += 3
-                    continue // Skip the default increment
-                } else {
-                    currentQuoteStr = symbol.toString()
-                }
-            } else if (quoteStr[0] == symbol && (idx + quoteStr.length) <= chars.length) {
-                val candidate = chars.substring(idx, idx + quoteStr.length)
-                if (candidate == quoteStr) {
-                    currentQuoteStr = null
-                    idx += candidate.length
-                    continue // Skip the default increment
-                }
+        val quoteStr = currentQuoteStr
+        if (quoteStr == null) {
+            if (idx + 2 < chars.length && chars[idx + 1] == symbol && chars[idx + 2] == symbol) {
+                currentQuoteStr = "$symbol$symbol$symbol"
+                idx += MULTILINE_STRING_QUOTE_LENGTH
+                continue  // Skip the default increment
+            } else {
+                currentQuoteStr = symbol.toString()
+            }
+        } else if (quoteStr[0] == symbol && (idx + quoteStr.length) <= chars.length) {
+            val candidate = chars.substring(idx, idx + quoteStr.length)
+            if (candidate == quoteStr) {
+                currentQuoteStr = null
+                idx += candidate.length
+                continue  // Skip the default increment
             }
         }
         idx += 1

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/parsers/StringUtils.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/parsers/StringUtils.kt
@@ -212,21 +212,36 @@ internal fun String.indexOfNextOutsideQuotes(
     startIndex: Int = 0,
 ): Int {
     val chars = this.drop(startIndex).replaceEscaped(allowEscapedQuotesInLiteralStrings)
-    var currentQuoteChar: Char? = null
+    var currentQuoteStr: String? = null
 
-    chars.forEachIndexed { idx, symbol ->
+    var idx = 0
+    while (idx < chars.length) {
+        val symbol = chars[idx]
         // take searchChar index if it's not enclosed in quotation marks
-        if (symbol == searchChar && currentQuoteChar == null) {
+        if (symbol == searchChar && currentQuoteStr == null) {
             return idx + startIndex
         }
 
         if (symbol == '\"' || symbol == '\'') {
-            if (currentQuoteChar == null) {
-                currentQuoteChar = symbol
-            } else if (currentQuoteChar == symbol) {
-                currentQuoteChar = null
+            val quoteStr = currentQuoteStr
+            if (quoteStr == null) {
+                if (idx + 2 < chars.length && chars[idx + 1] == symbol && chars[idx + 2] == symbol) {
+                    currentQuoteStr = "$symbol$symbol$symbol"
+                    idx += 3
+                    continue // Skip the default increment
+                } else {
+                    currentQuoteStr = symbol.toString()
+                }
+            } else if (quoteStr[0] == symbol && (idx + quoteStr.length) <= chars.length) {
+                val candidate = chars.substring(idx, idx + quoteStr.length)
+                if (candidate == quoteStr) {
+                    currentQuoteStr = null
+                    idx += candidate.length
+                    continue // Skip the default increment
+                }
             }
         }
+        idx += 1
     }
 
     return -1

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/parsers/TomlMultilineString.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/parsers/TomlMultilineString.kt
@@ -133,8 +133,11 @@ internal class TomlMultilineString(
             // symbols. Note that we're not using [indexOfNextOutsideOfQuotes] here because the last line of a
             // multiline string (eg `""" # this`) would consider the comment inside the quote.
             val closingSymbolsIdx = lines.last().lastIndexOf(multilineType.closingSymbols)
-            if (closingSymbolsIdx < 0) { return false }
-            lines.last().substring(closingSymbolsIdx + multilineType.closingSymbols.length)
+            if (closingSymbolsIdx < 0) {
+                return false
+            }
+            lines.last()
+                .substring(closingSymbolsIdx + multilineType.closingSymbols.length)
                 .takeBeforeComment(config.allowEscapedQuotesInLiteralStrings)
                 .trim()
                 .isEmpty()

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/parsers/TomlMultilineString.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/parsers/TomlMultilineString.kt
@@ -129,9 +129,15 @@ internal class TomlMultilineString(
                 clearedString.endsWith(multilineType.closingSymbols + multilineType.closingSymbols)
             }
         } else {
-            lines.last()
+            // Checks if this line ends with closing symbols, allowing for whitespace or a comment after those
+            // symbols. Note that we're not using [indexOfNextOutsideOfQuotes] here because the last line of a
+            // multiline string (eg `""" # this`) would consider the comment inside the quote.
+            val closingSymbolsIdx = lines.last().lastIndexOf(multilineType.closingSymbols)
+            if (closingSymbolsIdx < 0) { return false }
+            lines.last().substring(closingSymbolsIdx + multilineType.closingSymbols.length)
+                .takeBeforeComment(config.allowEscapedQuotesInLiteralStrings)
                 .trim()
-                .endsWith(multilineType.closingSymbols)
+                .isEmpty()
         }
     }
 

--- a/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/decoders/multiline/BasicMultilineStringDecoderTest.kt
+++ b/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/decoders/multiline/BasicMultilineStringDecoderTest.kt
@@ -286,4 +286,42 @@ class BasicMultilineStringDecoderTest {
             Toml.decodeFromString(test)
         )
     }
+
+    @Test
+    fun mixedQuotesWithHashSymbols() {
+        val test = """
+        a = $tripleQuotes
+        # Markdown Heading
+        
+        This is an example containing "a quote, where I've used an apostrophe inside." Later, I've
+        used another apostrophe.
+        
+        # Previously, this header was dropped by the parser.
+        $tripleQuotes
+        """.trimIndent()
+        assertEquals(
+            """
+            # Markdown Heading
+            
+            This is an example containing "a quote, where I've used an apostrophe inside." Later, I've
+            used another apostrophe.
+            
+            # Previously, this header was dropped by the parser.
+            """.trimIndent(),
+            Toml.decodeFromString<SimpleString>(test).a.trim()
+        )
+    }
+
+    @Test
+    fun commentAfterClosingQuotes() {
+        val test = """
+        a = $tripleQuotes
+        This failed the parser previously.
+        $tripleQuotes # A comment here previously threw an exception
+        """.trimIndent()
+        assertEquals(
+            "This failed the parser previously.\n",
+            Toml.decodeFromString<SimpleString>(test).a
+        )
+    }
 }


### PR DESCRIPTION
I had some pre-existing `.toml` files which embedded markdown, and these managed to trip up this parser. I managed to track down what caused the crashes and included some minimal reproductions as test cases. Before the included fixes these tests would fail, but they now pass.

In the below example the parser would not detect the multiline string as closing, since it required a line ending with `"""`.

```toml
a = """
Multiple lines are required to trigger this bug, triple-quotes are not enough
""" # A comment placed here causes a crash
```

In the below example the parser successfully finds the extent of the mutli-line string, but crashes when splitting the key and value. This happened because the pair is first processed via `takeBeforeComment`, which incorrectly found the markdown header inside the multiline string as a comment. This in turn caused the parser to attempt to assign the value `"""\nThis is an example containing "a quote, where I've used an apostrophe inside." Later, I've used another apostrophe.\n\n` , which crashes when `TomlBasicString` attempts to validate the quotes.

I've tracked the root of the issue to `indexOfNextOutsideQuotes`, which did not handle triple-quotes. The triple quote was handled as a sequence of three individual quotes (open, close, open) which could then be closed by a stray quote inside the string. This didn't cause issues in most cases, where quotes are balanced, but I ended up hitting it with the following pattern:

```toml
a = """
This is an example containing "a quote, where I've used an apostrophe inside." Later, I've used another apostrophe.

# This markdown header was detected as an actual comment
"""
```