### PR TITLE
Fix parsing of dotted keys inside array-of-tables

### DIFF
--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/pairs/TomlKeyValue.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/pairs/TomlKeyValue.kt
@@ -39,7 +39,11 @@ internal interface TomlKeyValue {
         // updating current KeyValue with this key
         this.key = realKeyWithoutDottedPrefix
         // tables should contain fully qualified name, so we need to add parental name
-        val parentalPrefix = if (parentNode is TomlTable) parentNode.fullTableKey.keyParts else emptyList()
+        val parentalPrefix = when (parentNode) {
+            is TomlTable -> parentNode.fullTableKey.keyParts
+            is TomlArrayOfTablesElement -> (parentNode.parent as TomlTable).fullTableKey.keyParts
+            else -> emptyList()
+        }
         // and creating a new table that will be created from dotted key
         return TomlTable(
             TomlKey(parentalPrefix + syntheticTablePrefix),

--- a/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/decoders/tables/ArrayOfTablesDecoderTest.kt
+++ b/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/decoders/tables/ArrayOfTablesDecoderTest.kt
@@ -257,4 +257,26 @@ class ArrayOfTablesDecoderTest {
             Toml.decodeFromString<Commands>(toml),
         )
     }
+
+    @Test
+    fun decodeWithDottedKeyValuesInside() {
+        @Serializable
+        data class Foo(val bar: Int)
+
+        @Serializable
+        data class Sample(val foo: Foo)
+
+        @Serializable
+        data class File(val samples: List<Sample>)
+
+        val toml = """
+        [[samples]]
+        foo.bar = 1
+        """.trimIndent()
+
+        assertEquals(
+            File(listOf(Sample(Foo(bar = 1)))),
+            Toml.decodeFromString<File>(toml),
+        )
+    }
 }

--- a/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/parsers/ArraysOfTablesTest.kt
+++ b/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/parsers/ArraysOfTablesTest.kt
@@ -598,6 +598,51 @@ class ArraysOfTablesTest {
                 |                 - TomlKeyValuePrimitive (shape="round")
                 |
                """.trimMargin(),
-            parsedToml.prettyStr())
+            parsedToml.prettyStr()
+        )
+    }
+
+    @Test
+    fun dottedKeysInsideTable() {
+        val string = """
+            [[table]]
+            simple = 1
+            item.simple = 2
+            
+            [[table]]
+            item.complex = { a = 3, b = 4 }
+
+            [[table]]
+            simple = 5
+            item.simple = 6
+            item.complex = { a = 7, b = 8 }
+        """.trimIndent()
+        val parsedToml = tomlParser.parseString(string)
+
+        assertEquals(
+            """
+                | - TomlFile (rootNode)
+                |     - TomlTable ([[table]])
+                |         - TomlArrayOfTablesElement (technical_node)
+                |             - TomlKeyValuePrimitive (simple=1)
+                |             - TomlTable ([table.item])
+                |                 - TomlKeyValuePrimitive (simple=2)
+                |         - TomlArrayOfTablesElement (technical_node)
+                |             - TomlTable ([table.item])
+                |                 - TomlTable ([table.item.complex])
+                |                     - TomlKeyValuePrimitive (a=3)
+                |                     - TomlKeyValuePrimitive (b=4)
+                |         - TomlArrayOfTablesElement (technical_node)
+                |             - TomlKeyValuePrimitive (simple=5)
+                |             - TomlTable ([table.item])
+                |                 - TomlKeyValuePrimitive (simple=6)
+                |             - TomlTable ([table.item])
+                |                 - TomlTable ([table.item.complex])
+                |                     - TomlKeyValuePrimitive (a=7)
+                |                     - TomlKeyValuePrimitive (b=8)
+                |
+               """.trimMargin(),
+            parsedToml.prettyStr()
+        )
     }
 }

--- a/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/parsers/TomlTableTest.kt
+++ b/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/parsers/TomlTableTest.kt
@@ -118,4 +118,25 @@ class TomlTableTest {
         val table = TomlTable("[abcd]", 0, TableType.PRIMITIVE)
         assertEquals(table.fullTableKey.toString(), "abcd")
     }
+
+    @Test
+    fun dottedKeysInsideTable() {
+        val string = """
+            [table]
+            simple = 1
+            item.simple = 2
+        """.trimIndent()
+        val parsedToml = Toml.tomlParser.parseString(string)
+        assertEquals(
+            """
+                | - TomlFile (rootNode)
+                |     - TomlTable ([table])
+                |         - TomlKeyValuePrimitive (simple=1)
+                |         - TomlTable ([table.item])
+                |             - TomlKeyValuePrimitive (simple=2)
+                |
+               """.trimMargin(),
+            parsedToml.prettyStr()
+        )
+    }
 }


### PR DESCRIPTION
Previously, the parser would produce the wrong tree structure for use of `dotted.key = "value"` while inside of an `[[arrayOfTables]]`. As an example:

```toml
[[arrayOfTables]]
dotted.key = "value"
```

Before this fix, this is parsed as:

```
 - TomlFile (rootNode)
     - TomlTable ([[arrayOfTables]])
         - TomlArrayOfTablesElement (technical_node)
     - TomlTable ([dotted])
         - TomlKeyValuePrimitive (key="value")
```

After this fix, it is now correctly parsed as:

```
- TomlFile (rootNode)
     - TomlTable ([[arrayOfTables]])
         - TomlArrayOfTablesElement (technical_node)
             - TomlTable ([arrayOfTables.dotted])
                 - TomlKeyValuePrimitive (key="value")
```

This matches the structure that was already working when using a non-array table:

```toml
[table]
dotted.key = "value"
```

```
 - TomlFile (rootNode)
     - TomlTable ([table])
         - TomlTable ([table.dotted])
             - TomlKeyValuePrimitive (key="value")
```

And this time, I remembered to make sure it passes lint 😄 