### PR TITLE
Update all non-major dependencies (except core Kotlin)

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -14,5 +14,5 @@ dependencies {
     implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.8")
     implementation("io.github.gradle-nexus:publish-plugin:2.0.0")
     implementation("org.ajoberstar.reckon:reckon-gradle:0.19.2")
-    implementation("org.ajoberstar.grgit:grgit-core:5.3.0")
+    implementation("org.ajoberstar.grgit:grgit-core:5.3.2")
 }

--- a/buildSrc/src/main/kotlin/com/akuleshov7/Versions.kt
+++ b/buildSrc/src/main/kotlin/com/akuleshov7/Versions.kt
@@ -7,6 +7,6 @@
 object Versions {
     const val KOTLIN = "2.2.0"
     const val JUNIT = "5.7.1"
-    const val OKIO = "3.11.0"
+    const val OKIO = "3.16.0"
     const val SERIALIZATION = "1.9.0"
 }

--- a/ktoml-core/build.gradle.kts
+++ b/ktoml-core/build.gradle.kts
@@ -59,7 +59,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 api("org.jetbrains.kotlinx:kotlinx-serialization-core:${Versions.SERIALIZATION}")
-                api("org.jetbrains.kotlinx:kotlinx-datetime:0.6.2")
+                api("org.jetbrains.kotlinx:kotlinx-datetime:0.7.1-0.6.x-compat")
                 implementation("org.jetbrains.kotlin:kotlin-stdlib:${Versions.KOTLIN}")
             }
         }
@@ -92,7 +92,7 @@ kotlin {
         val jvmTest by getting {
             dependencies {
                 implementation(kotlin("test-junit5"))
-                implementation("org.junit.jupiter:junit-jupiter-engine:5.12.2")
+                implementation("org.junit.jupiter:junit-jupiter-engine:5.13.4")
             }
         }
         all {

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/decoders/TomlAbstractDecoder.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/decoders/TomlAbstractDecoder.kt
@@ -15,7 +15,7 @@ import com.akuleshov7.ktoml.utils.IntegerLimitsEnum.*
 import com.akuleshov7.ktoml.utils.UnsignedIntegerLimitsEnum
 import com.akuleshov7.ktoml.utils.UnsignedIntegerLimitsEnum.*
 import com.akuleshov7.ktoml.utils.convertSpecialCharacters
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.LocalTime
@@ -24,6 +24,7 @@ import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.descriptors.SerialKind
 import kotlinx.serialization.encoding.AbstractDecoder
+import kotlin.time.ExperimentalTime
 
 /**
  * Abstract Decoder for TOML format that is inherited by each and every decoder in this project.
@@ -31,6 +32,7 @@ import kotlinx.serialization.encoding.AbstractDecoder
  */
 @ExperimentalSerializationApi
 public abstract class TomlAbstractDecoder : AbstractDecoder() {
+    @OptIn(ExperimentalTime::class)
     private val instantSerializer = Instant.serializer()
     private val localDateTimeSerializer = LocalDateTime.serializer()
     private val localDateSerializer = LocalDate.serializer()
@@ -89,6 +91,7 @@ public abstract class TomlAbstractDecoder : AbstractDecoder() {
     override fun decodeDouble(): Double = decodePrimitiveType()
     override fun decodeString(): String = decodePrimitiveType()
 
+    @OptIn(ExperimentalTime::class)
     protected fun DeserializationStrategy<*>.isDateTime(): Boolean =
         descriptor == instantSerializer.descriptor ||
                 descriptor == localDateTimeSerializer.descriptor ||
@@ -101,6 +104,7 @@ public abstract class TomlAbstractDecoder : AbstractDecoder() {
                 descriptor == unsignedIntSerializer.descriptor ||
                 descriptor == unsignedLongSerializer.descriptor
 
+    @OptIn(ExperimentalTime::class)
     @Suppress("UNCHECKED_CAST")
     override fun <T> decodeSerializableValue(deserializer: DeserializationStrategy<T>): T =
         when (deserializer.descriptor) {

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/decoders/TomlAbstractDecoder.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/decoders/TomlAbstractDecoder.kt
@@ -15,6 +15,8 @@ import com.akuleshov7.ktoml.utils.IntegerLimitsEnum.*
 import com.akuleshov7.ktoml.utils.UnsignedIntegerLimitsEnum
 import com.akuleshov7.ktoml.utils.UnsignedIntegerLimitsEnum.*
 import com.akuleshov7.ktoml.utils.convertSpecialCharacters
+
+import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
@@ -24,7 +26,6 @@ import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.descriptors.SerialKind
 import kotlinx.serialization.encoding.AbstractDecoder
-import kotlin.time.ExperimentalTime
 
 /**
  * Abstract Decoder for TOML format that is inherited by each and every decoder in this project.

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/encoders/TomlAbstractEncoder.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/encoders/TomlAbstractEncoder.kt
@@ -8,16 +8,18 @@ import com.akuleshov7.ktoml.tree.nodes.TomlNode
 import com.akuleshov7.ktoml.tree.nodes.pairs.values.*
 import com.akuleshov7.ktoml.utils.isBareKey
 import com.akuleshov7.ktoml.utils.isLiteralKeyCandidate
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.LocalTime
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerializationStrategy
+import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.AbstractEncoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.modules.SerializersModule
+import kotlin.time.ExperimentalTime
 
 /**
  * An abstract Encoder for the TOML format.
@@ -35,6 +37,7 @@ public abstract class TomlAbstractEncoder protected constructor(
     override val serializersModule: SerializersModule,
 ) : AbstractEncoder() {
     private var isNextElementKey = false
+    @OptIn(ExperimentalTime::class)
     private val instantDescriptor = Instant.serializer().descriptor
     private val localDateTimeDescriptor = LocalDateTime.serializer().descriptor
     private val localDateDescriptor = LocalDate.serializer().descriptor

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/encoders/TomlAbstractEncoder.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/encoders/TomlAbstractEncoder.kt
@@ -8,6 +8,8 @@ import com.akuleshov7.ktoml.tree.nodes.TomlNode
 import com.akuleshov7.ktoml.tree.nodes.pairs.values.*
 import com.akuleshov7.ktoml.utils.isBareKey
 import com.akuleshov7.ktoml.utils.isLiteralKeyCandidate
+
+import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
@@ -19,7 +21,6 @@ import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.AbstractEncoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.modules.SerializersModule
-import kotlin.time.ExperimentalTime
 
 /**
  * An abstract Encoder for the TOML format.
@@ -37,6 +38,7 @@ public abstract class TomlAbstractEncoder protected constructor(
     override val serializersModule: SerializersModule,
 ) : AbstractEncoder() {
     private var isNextElementKey = false
+
     @OptIn(ExperimentalTime::class)
     private val instantDescriptor = Instant.serializer().descriptor
     private val localDateTimeDescriptor = LocalDateTime.serializer().descriptor

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/pairs/values/TomlDateTime.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/pairs/values/TomlDateTime.kt
@@ -3,11 +3,12 @@ package com.akuleshov7.ktoml.tree.nodes.pairs.values
 import com.akuleshov7.ktoml.TomlOutputConfig
 import com.akuleshov7.ktoml.exceptions.TomlWritingException
 import com.akuleshov7.ktoml.writers.TomlEmitter
+
+import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.LocalTime
-import kotlin.time.ExperimentalTime
 
 /**
  * Toml AST Node for a representation of date-time types (offset date-time, local date-time, local date, local time)

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/pairs/values/TomlDateTime.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/tree/nodes/pairs/values/TomlDateTime.kt
@@ -3,10 +3,11 @@ package com.akuleshov7.ktoml.tree.nodes.pairs.values
 import com.akuleshov7.ktoml.TomlOutputConfig
 import com.akuleshov7.ktoml.exceptions.TomlWritingException
 import com.akuleshov7.ktoml.writers.TomlEmitter
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.LocalTime
+import kotlin.time.ExperimentalTime
 
 /**
  * Toml AST Node for a representation of date-time types (offset date-time, local date-time, local date, local time)
@@ -22,6 +23,7 @@ internal constructor(
         emitter: TomlEmitter,
         config: TomlOutputConfig
     ) {
+        @OptIn(ExperimentalTime::class)
         when (val content = content) {
             is Instant -> emitter.emitValue(content)
             is LocalDateTime -> emitter.emitValue(content)
@@ -35,6 +37,7 @@ internal constructor(
     }
 
     public companion object {
+        @OptIn(ExperimentalTime::class)
         private fun String.parseToDateTime(): Any = try {
             // Offset date-time
             // TOML spec allows a space instead of the T, try replacing the first space by a T

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/writers/TomlEmitter.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/writers/TomlEmitter.kt
@@ -7,10 +7,11 @@ import com.akuleshov7.ktoml.utils.isLiteralKeyCandidate
 import com.akuleshov7.ktoml.utils.newLineChar
 import com.akuleshov7.ktoml.writers.IntegerRepresentation.DECIMAL
 import com.akuleshov7.ktoml.writers.IntegerRepresentation.GROUPED
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.LocalTime
+import kotlin.time.ExperimentalTime
 
 /**
  * Abstracts the specifics of writing TOML files into "emit" operations.
@@ -286,6 +287,7 @@ public abstract class TomlEmitter(config: TomlOutputConfig) {
      * @param instant
      * @return this instance
      */
+    @OptIn(ExperimentalTime::class)
     public fun emitValue(instant: Instant): TomlEmitter = emit(instant.toString())
 
     /**

--- a/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/writers/TomlEmitter.kt
+++ b/ktoml-core/src/commonMain/kotlin/com/akuleshov7/ktoml/writers/TomlEmitter.kt
@@ -7,11 +7,12 @@ import com.akuleshov7.ktoml.utils.isLiteralKeyCandidate
 import com.akuleshov7.ktoml.utils.newLineChar
 import com.akuleshov7.ktoml.writers.IntegerRepresentation.DECIMAL
 import com.akuleshov7.ktoml.writers.IntegerRepresentation.GROUPED
+
+import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.LocalTime
-import kotlin.time.ExperimentalTime
 
 /**
  * Abstracts the specifics of writing TOML files into "emit" operations.

--- a/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/decoders/primitives/DateTimeDecoderTest.kt
+++ b/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/decoders/primitives/DateTimeDecoderTest.kt
@@ -2,23 +2,19 @@ package com.akuleshov7.ktoml.decoders.primitives
 
 import com.akuleshov7.ktoml.Toml
 import com.akuleshov7.ktoml.exceptions.ParseException
-import kotlinx.datetime.Instant
-import kotlinx.datetime.LocalDate
-import kotlinx.datetime.LocalDateTime
-import kotlinx.datetime.LocalTime
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toInstant
+import kotlinx.datetime.*
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
+@kotlin.time.ExperimentalTime
 class DateTimeDecoderTest {
 
     @Serializable
     data class TimeTable(
-        val instants: List<Instant>,
+        val instants: List<kotlin.time.Instant>,
         val localDateTimes: List<LocalDateTime>,
         val localDate: LocalDate,
         val localTime: LocalTime,
@@ -26,6 +22,7 @@ class DateTimeDecoderTest {
     )
 
     @Test
+    @kotlin.time.ExperimentalTime
     fun testDateParsing() {
         val toml = """
             instants = [1979-05-27T07:32:00Z, 1979-05-27T00:32:00-07:00, 1979-05-27T00:32:00.999999-07:00, 1979-05-27 07:32:00Z]

--- a/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/encoders/DateTimeEncoderTest.kt
+++ b/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/encoders/DateTimeEncoderTest.kt
@@ -3,11 +3,13 @@ package com.akuleshov7.ktoml.encoders
 import kotlinx.datetime.*
 import kotlinx.serialization.Serializable
 import kotlin.test.Test
+import kotlin.time.Instant
 
+@kotlin.time.ExperimentalTime
 class DateTimeEncoderTest {
     @Serializable
     data class DateTimes(
-        val instant: Instant = default.toInstant(TimeZone.UTC),
+        val instant: kotlin.time.Instant = default.toInstant(TimeZone.UTC),
         val instantWithNanos: Instant = defaultWithNanos.toInstant(TimeZone.UTC),
         val localDateTime: LocalDateTime = default,
         val localDateTimeWithNanos: LocalDateTime = defaultWithNanos,

--- a/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/encoders/TomlDocsEncoderTest.kt
+++ b/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/encoders/TomlDocsEncoderTest.kt
@@ -18,6 +18,7 @@ import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.encoding.encodeCollection
 import kotlin.test.Test
 
+@kotlin.time.ExperimentalTime
 class TomlDocsEncoderTest {
     @Serializable
     data class ReadMe(
@@ -30,7 +31,7 @@ class TomlDocsEncoderTest {
     @Serializable
     data class Owner(
         val name: String = "Tom Preston-Werner",
-        val dob: Instant =
+        val dob: kotlin.time.Instant =
                 LocalDateTime(1979, 5, 27, 15, 32, 0)
                     .toInstant(TimeZone.UTC)
     )

--- a/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/writers/ValueWriteTest.kt
+++ b/ktoml-core/src/commonTest/kotlin/com/akuleshov7/ktoml/writers/ValueWriteTest.kt
@@ -15,6 +15,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
+@kotlin.time.ExperimentalTime
 class PrimitiveValueWriteTest {
     @Test
     fun literalStringWriteTest() {
@@ -127,7 +128,7 @@ class PrimitiveValueWriteTest {
         val localD = "1979-05-27"
         val localT = "07:32:32"
 
-        testTomlValue(TomlDateTime(Instant.parse(instant)), instant)
+        testTomlValue(TomlDateTime(kotlin.time.Instant.parse(instant)), instant)
         testTomlValue(TomlDateTime(LocalDateTime.parse(localDt)), localDt)
         testTomlValue(TomlDateTime(LocalDate.parse(localD)), localD)
         testTomlValue(TomlDateTime(LocalTime.parse(localT)), localT)

--- a/ktoml-core/src/macosX64Main/kotlin/com/akuleshov7/ktoml/utils/UtilsMac.kt
+++ b/ktoml-core/src/macosX64Main/kotlin/com/akuleshov7/ktoml/utils/UtilsMac.kt
@@ -8,6 +8,7 @@ import kotlin.experimental.ExperimentalNativeApi
 
 @Suppress("MAGIC_NUMBER")
 @OptIn(ExperimentalNativeApi::class)
+@Throws(IllegalArgumentException::class)
 internal actual fun StringBuilder.appendCodePointCompat(codePoint: Int): StringBuilder = when (codePoint) {
     in 0 until Char.MIN_SUPPLEMENTARY_CODE_POINT -> append(codePoint.toChar())
     in Char.MIN_SUPPLEMENTARY_CODE_POINT..Char.MAX_CODE_POINT -> {

--- a/ktoml-core/src/mingwX64Main/kotlin/com/akuleshov7/ktoml/utils/UtilsWin.kt
+++ b/ktoml-core/src/mingwX64Main/kotlin/com/akuleshov7/ktoml/utils/UtilsWin.kt
@@ -8,6 +8,7 @@ import kotlin.experimental.ExperimentalNativeApi
 
 @Suppress("MAGIC_NUMBER")
 @OptIn(ExperimentalNativeApi::class)
+@Throws(IllegalArgumentException::class)
 internal actual fun StringBuilder.appendCodePointCompat(codePoint: Int): StringBuilder = when (codePoint) {
     in 0 until Char.MIN_SUPPLEMENTARY_CODE_POINT -> append(codePoint.toChar())
     in Char.MIN_SUPPLEMENTARY_CODE_POINT..Char.MAX_CODE_POINT -> {

--- a/ktoml-file/build.gradle.kts
+++ b/ktoml-file/build.gradle.kts
@@ -57,7 +57,7 @@ kotlin {
         val jvmTest by getting {
             dependencies {
                 implementation(kotlin("test-junit5"))
-                implementation("org.junit.jupiter:junit-jupiter-engine:5.12.2")
+                implementation("org.junit.jupiter:junit-jupiter-engine:5.13.4")
             }
         }
 

--- a/ktoml-source/build.gradle.kts
+++ b/ktoml-source/build.gradle.kts
@@ -58,7 +58,7 @@ kotlin {
         val jvmTest by getting {
             dependencies {
                 implementation(kotlin("test-junit5"))
-                implementation("org.junit.jupiter:junit-jupiter-engine:5.12.2")
+                implementation("org.junit.jupiter:junit-jupiter-engine:5.13.4")
             }
         }
 


### PR DESCRIPTION
### What's done:
- Reworked kotlin.time.Instant usages to a new API
- Updated minor versions, especially org.jetbrains.kotlinx:kotlinx-datetime:0.7.1-0.6.x-compat